### PR TITLE
Add accessibility attributes to SegmentioCell

### DIFF
--- a/MiDSegment/Source/Cells/SegmentioCell.swift
+++ b/MiDSegment/Source/Cells/SegmentioCell.swift
@@ -21,7 +21,15 @@ class SegmentioCell: UICollectionViewCell {
     
     var topConstraint: NSLayoutConstraint?
     var bottomConstraint: NSLayoutConstraint?
-    var cellSelected = false
+    var cellSelected = false {
+        didSet {
+            if cellSelected {
+                containerView?.accessibilityTraits.insert(.selected)
+            } else {
+                containerView?.accessibilityTraits.remove(.selected)
+            }
+        }
+    }
     
     private var options = SegmentioOptions()
     private var style = SegmentioStyle.imageOverLabel
@@ -90,6 +98,9 @@ class SegmentioCell: UICollectionViewCell {
         
         setupConstraintsForSubviews()
         addVerticalSeparator()
+        
+        containerView?.isAccessibilityElement = true
+        containerView?.accessibilityTraits.insert(.button)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -105,12 +116,14 @@ class SegmentioCell: UICollectionViewCell {
         case .onlyLabel:
             badgePresenter.removeBadgeFromContainerView(containerView!)
             segmentTitleLabel?.text = nil
+            containerView?.accessibilityLabel = nil
         case .onlyImage:
             badgePresenter.removeBadgeFromContainerView(imageContainerView!)
             segmentImageView?.image = nil
         default:
             badgePresenter.removeBadgeFromContainerView(containerView!)
             segmentTitleLabel?.text = nil
+            containerView?.accessibilityLabel = nil
             segmentImageView?.image = nil
         }
     }
@@ -301,6 +314,7 @@ class SegmentioCell: UICollectionViewCell {
             segmentTitleLabel?.textColor = defaultState.titleTextColor
             segmentTitleLabel?.font = defaultState.titleFont
             segmentTitleLabel?.text = content.title
+            containerView?.accessibilityLabel = content.title
             segmentTitleLabel?.lineBreakMode = .byTruncatingMiddle
         }
     }


### PR DESCRIPTION
Add accessibility attributes to SegmentioCell to more closely mirror the accessibility attributes of a native iOS UISegmentedControl.

This is what a native UISegmentedControl is like over VoiceOver — note how it announces “selected” for the selected one and “button” for each one to indicate that you can tap it.
https://user-images.githubusercontent.com/26018831/136992552-eda46884-ac51-43ea-8093-c6bb5432ea3d.MP4

This is how SegmentioCell currently behaves, with no announcement of button or selected tab:
https://user-images.githubusercontent.com/26018831/136992726-677934de-b023-4aef-b9cd-b3fa8a2ab032.MP4

And this is how SegmentioCell behaves with VoiceOver with these simple changes:
https://user-images.githubusercontent.com/26018831/136992818-4c11059b-0fab-43a8-956a-92184cd289c1.MP4